### PR TITLE
Added pythonnet plugin support for Nuitka in build scripts and updated version check functionality in the app

### DIFF
--- a/.github/workflows/build-on-release.yml
+++ b/.github/workflows/build-on-release.yml
@@ -31,6 +31,13 @@ jobs:
           python -m pip install --upgrade pip
           pip install nuitka
           pip install -r UI/requirements.txt
+        
+      - name: Update APP_VERSION in app.py
+        shell: pwsh
+        run: |
+          $tag = '${{ github.event.inputs.tag }}'
+          $version = $tag.TrimStart('v')
+          (Get-Content UI/app.py) -replace 'APP_VERSION = ".*"', "APP_VERSION = `"$version`"" | Set-Content UI/app.py
 
       - name: Build executable with Nuitka
         shell: cmd
@@ -59,6 +66,7 @@ jobs:
           --include-data-dir=UI\assets=assets ^
           --output-dir=dist ^
           --enable-plugin=tk-inter ^
+          --enable-plugin=pythonnet ^
           --remove-output ^
           --assume-yes-for-downloads ^
           --nofollow-import-to=tkinter ^

--- a/UI/app.py
+++ b/UI/app.py
@@ -15,6 +15,8 @@ from dotenv import load_dotenv
 sys.path.append(os.path.dirname(__file__))
 from src.models.capture import PacketCapture  # Add capture import
 
+APP_VERSION = "2.0.0"
+
 # Initialize logging first
 setup_logging()
 logger = logging.getLogger(__name__)
@@ -298,7 +300,11 @@ class Api:
 # Initialize API
 api = Api()
 
-# JSON API endpoints
+# JSON API endpoint
+@server.route('/api/version')
+def api_version():
+    return jsonify({"version": APP_VERSION})
+
 @server.route('/api/characters')
 def api_characters():
     return jsonify(api.get_characters())

--- a/UI/static/js/app.js
+++ b/UI/static/js/app.js
@@ -89,3 +89,73 @@ document.addEventListener('DOMContentLoaded', () => {
         // You can also trigger data refresh or enable UI here
     });
 });
+
+// Version check and update notification
+async function checkForUpdates() {
+    try {
+        // Fetch local version
+        const localRes = await fetch('/api/version');
+        const localData = await localRes.json();
+        const localVersion = localData.version;
+
+        // Fetch latest release info from GitHub API
+        const apiUrl = 'https://api.github.com/repos/Beelzebub2/DnDTools/releases/latest';
+        const remoteRes = await fetch(apiUrl, { cache: 'no-store' });
+        if (!remoteRes.ok) return;
+        const releaseData = await remoteRes.json();
+        const remoteVersion = (releaseData.tag_name || '').replace(/^v/, '').trim();
+
+        if (remoteVersion && isNewerVersion(remoteVersion, localVersion)) {
+            showUpdatePopup(remoteVersion, localVersion, releaseData.html_url);
+        }
+    } catch (e) {
+        // Silently ignore update check errors
+    }
+}
+
+function isNewerVersion(remote, local) {
+    // Simple semver compare: '1.2.3' > '1.2.2'
+    const r = remote.split('.').map(Number);
+    const l = local.split('.').map(Number);
+    for (let i = 0; i < Math.max(r.length, l.length); i++) {
+        if ((r[i] || 0) > (l[i] || 0)) return true;
+        if ((r[i] || 0) < (l[i] || 0)) return false;
+    }
+    return false;
+}
+
+function showUpdatePopup(remoteVersion, localVersion, releaseUrl) {
+    // Remove any existing popup
+    const existing = document.getElementById('update-popup');
+    if (existing) existing.remove();
+    const popup = document.createElement('div');
+    popup.id = 'update-popup';
+    popup.style.position = 'fixed';
+    popup.style.bottom = '30px';
+    popup.style.right = '30px';
+    popup.style.background = '#222';
+    popup.style.color = '#e4c869';
+    popup.style.padding = '20px 28px';
+    popup.style.borderRadius = '10px';
+    popup.style.boxShadow = '0 2px 12px #000a';
+    popup.style.zIndex = '99999';
+    popup.innerHTML = `
+        <div style="display:flex;align-items:center;gap:12px;">
+            <span class="material-icons" style="font-size:28px;color:#e4c869;">system_update_alt</span>
+            <div>
+                <b>New Update Available!</b><br>
+                <span style="font-size:13px;">Current: v${localVersion} &nbsp; Latest: v${remoteVersion}</span>
+            </div>
+        </div>
+        <div style="margin-top:10px;text-align:right;">
+            <a href="${releaseUrl || 'https://github.com/Beelzebub2/DnDTools/releases'}" target="_blank" style="color:#e4c869;text-decoration:underline;font-size:14px;">Download Update</a>
+            <button id="close-update-popup" style="margin-left:10px;background:none;border:none;color:#aaa;font-size:16px;cursor:pointer;">✕</button>
+        </div>
+    `;
+    document.body.appendChild(popup);
+    document.getElementById('close-update-popup').onclick = () => popup.remove();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    checkForUpdates();
+});

--- a/build_app.bat
+++ b/build_app.bat
@@ -25,6 +25,7 @@ python -m nuitka ^
 --include-data-dir=UI\assets=assets ^
 --output-dir=dist ^
 --enable-plugin=tk-inter ^
+--enable-plugin=pythonnet ^
 --remove-output ^
 --assume-yes-for-downloads ^
 --enable-plugin=no-qt ^


### PR DESCRIPTION
This pull request introduces version management and update notification functionality to the project, along with minor build configuration updates. The most important changes include adding an `APP_VERSION` constant, implementing an API endpoint to expose the version, and creating a client-side mechanism to check for updates and notify users.

### Version management:

* Added an `APP_VERSION` constant to `UI/app.py` to define the current application version. This value is dynamically updated during the release build process using a new step in the GitHub Actions workflow. (`.github/workflows/build-on-release.yml`, `UI/app.py`) [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747R35-R41) [[2]](diffhunk://#diff-1aad2c90d5547bdc1e200d26fc19f4f7ffafce9c4c13b2702a45c00f52e91877R18-R19)
* Introduced a new API endpoint `/api/version` in `UI/app.py` to expose the current application version to the client.

### Update notification:

* Added a client-side script in `UI/static/js/app.js` to compare the local version with the latest release version from GitHub. If a newer version is available, a notification popup is displayed with a link to the release.

### Build configuration updates:

* Updated the `build-on-release.yml` workflow and `build_app.bat` script to include the `pythonnet` plugin during the build process. (`.github/workflows/build-on-release.yml`, `build_app.bat`) [[1]](diffhunk://#diff-38b8f05daa17f69966bc451e300246f38f28ede7eca043231688b539d5688747R69) [[2]](diffhunk://#diff-e052d0cd9e3033e008df4a920b29037392f841c6e7cb16b86f86f78f024cb069R28)