### PR TITLE
Refactor directory creation in StashManager: ensure only data directory exists and update comments for clarity

### DIFF
--- a/UI/src/models/appdirs.py
+++ b/UI/src/models/appdirs.py
@@ -36,7 +36,6 @@ def get_data_dir():
 
 def get_output_dir():
     output_dir = os.path.join(get_appdata_dir(), 'output')
-    os.makedirs(output_dir, exist_ok=True)
     return output_dir
 
 def get_logs_dir():

--- a/UI/src/models/stash_manager.py
+++ b/UI/src/models/stash_manager.py
@@ -15,9 +15,8 @@ class StashManager:
     def __init__(self, resource_dir: str):
         self.data_dir = get_data_dir()
         self.output_dir = get_output_dir()
-        # Ensure directories exist
+        # Only ensure data directory exists, not output directory
         os.makedirs(self.data_dir, exist_ok=True)
-        os.makedirs(self.output_dir, exist_ok=True)
         
         self.characters_cache = {}
         self._load_data()
@@ -203,22 +202,14 @@ class StashManager:
         return output
 
     def get_character_stash_previews(self, character_id):
-        """Get preview images and detailed item data for all stashes of a character"""
+        """Get detailed item data for all stashes of a character without generating image previews"""
         stashes = self.get_character_stashes(character_id)
-        preview_paths = {}
+        preview_paths = {}  # Keep empty dictionary for backward compatibility
         stash_data = {}
         
         for stash_id, items in stashes.items():
             try:
-                # Create image previews for backward compatibility
-                item_infos = [ItemInfo(**item) for item in items]
-                preview = self.preview_generator.generate_preview(stash_id, item_infos)
-                outname = f"stash_preview_{character_id}_{stash_id}.png"
-                outpath = os.path.join(self.output_dir, outname)
-                preview.save(outpath)
-                preview_paths[stash_id] = f"/output/{outname}"
-                
-                # Create enhanced data for interactive grid rendering
+                # Create enhanced data for interactive grid rendering only
                 enhanced_items = []
                 for item in items:
                     try:
@@ -283,6 +274,8 @@ class StashManager:
                         })
                         
                 stash_data[stash_id] = enhanced_items
+                # Add a placeholder path for backward compatibility
+                preview_paths[stash_id] = "/static/img/placeholder.png"
             except Exception as e:
                 print(f"Error processing stash {stash_id}: {str(e)}")
                 import traceback
@@ -290,7 +283,7 @@ class StashManager:
                 preview_paths[stash_id] = "/static/img/error.png"  # Fallback image
                 stash_data[stash_id] = []  # Empty stash data as fallback
         
-        # Return both the image paths (for backward compatibility) and the enhanced data
+        # Return both the placeholder paths (for backward compatibility) and the enhanced data
         response = {
             'previewImages': preview_paths,
             'stashData': stash_data

--- a/UI/static/js/installing.js
+++ b/UI/static/js/installing.js
@@ -92,7 +92,7 @@ async function performRestart() {
 
         // Fallback to standard API endpoint
         await fetch('/api/restart', { method: 'POST' });
-        
+
         // Give the server a moment to initiate restart
         setTimeout(() => {
             // If we're still here after 2 seconds, try to reload


### PR DESCRIPTION
This pull request refactors directory management and modifies how stash previews are handled in the `StashManager` class. The changes remove the creation of output directories and image previews, replacing them with placeholders for backward compatibility.

### Directory Management Updates:
* [`UI/src/models/appdirs.py`](diffhunk://#diff-fc12b251aedb383ac3780cfab6c3cc4b44393efab5059df38ca485da20d62f14L39): Removed the creation of the `output` directory in the `get_output_dir` function.
* [`UI/src/models/stash_manager.py`](diffhunk://#diff-c9ba26719a47272cd74227c61be918a16288487cd247554a915573b31e5b8c4cL18-L20): Updated the `StashManager` constructor to ensure only the `data` directory is created, no longer creating the `output` directory.

### Stash Previews Refactoring:
* [`UI/src/models/stash_manager.py`](diffhunk://#diff-c9ba26719a47272cd74227c61be918a16288487cd247554a915573b31e5b8c4cL206-R212): Modified `get_character_stash_previews` to stop generating image previews for stashes. Placeholder paths are now returned instead for backward compatibility. [[1]](diffhunk://#diff-c9ba26719a47272cd74227c61be918a16288487cd247554a915573b31e5b8c4cL206-R212) [[2]](diffhunk://#diff-c9ba26719a47272cd74227c61be918a16288487cd247554a915573b31e5b8c4cR277-R286)