### PR TITLE
Cache dependencies

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -25,6 +25,16 @@ jobs:
           cache: 'pip'
           cache-dependency-path: UI/requirements.txt
 
+      - name: Cache PyInstaller
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/AppData/Local/pip/Cache
+          key: ${{ runner.os }}-pyinstaller-${{ hashFiles('UI/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pyinstaller-
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/update-items.yml
+++ b/.github/workflows/update-items.yml
@@ -14,9 +14,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+        cache: 'pip'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
This pull request introduces improvements to the GitHub Actions workflows for building, releasing, and updating items. The main changes focus on optimizing dependency caching and updating the Python setup action to enhance workflow efficiency.

**Workflow optimization and dependency caching:**

* Added a step to cache PyInstaller dependencies in the `build-and-release.yml` workflow, which helps speed up builds by reusing previously downloaded packages.
* Updated the Python setup action to use `actions/setup-python@v5` in the `update-items.yml` workflow and enabled pip cache, ensuring faster and more reliable dependency installation.