### PR TITLE
Fixed typo that prevented auto update from working 

### DIFF
--- a/UI/app.py
+++ b/UI/app.py
@@ -45,7 +45,7 @@ version_cache = None
 version_cache_timestamp = 0
 VERSION_CACHE_DURATION = 6 * 60 * 60  # 6 hours in seconds
 
-APP_VERSION = "3.4.7"
+APP_VERSION = "3.5.0"
 UPDATE_MANIFEST_URL = os.environ.get(
     "DND_UPDATE_MANIFEST",
     "https://github.com/Beelzebub2/DnDTools/releases/latest/download/update-manifest.json",

--- a/UI/app.py
+++ b/UI/app.py
@@ -48,7 +48,7 @@ VERSION_CACHE_DURATION = 6 * 60 * 60  # 6 hours in seconds
 APP_VERSION = "3.4.7"
 UPDATE_MANIFEST_URL = os.environ.get(
     "DND_UPDATE_MANIFEST",
-    "https://github.com/Beelzebub2/DnDTools/releases/download/latest/update-manifest.json",
+    "https://github.com/Beelzebub2/DnDTools/releases/latest/download/update-manifest.json",
 )
 UPDATE_CACHE_DURATION = 5 * 60
 AUTO_UPDATE_SILENT = os.environ.get("DND_UPDATE_SILENT", "1").lower() not in {"0", "false", "no", "off"}


### PR DESCRIPTION
This pull request makes a minor update to the application version and corrects the update manifest URL to ensure the app fetches updates from the correct location.

- Versioning:
  * Updated `APP_VERSION` from `"3.4.7"` to `"3.5.0"` in `UI/app.py`.

- Update mechanism:
  * Fixed the `UPDATE_MANIFEST_URL` to point to the correct "latest/download" path, ensuring the app checks for updates at the right location.